### PR TITLE
feat: expose Cloud Armor JSON parsing option

### DIFF
--- a/docs/TERRAFORM.md
+++ b/docs/TERRAFORM.md
@@ -2,25 +2,26 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.10 |
 | google | >= 6.14, < 8 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | cloud_armor_policy | GoogleCloudPlatform/cloud-armor/google | ~> 6.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | project_id | Google Cloud project ID. | `string` | n/a | yes |
 | adaptive_protection_auto_deploy_overwrites | Values to overwrite the default Adaptive Protection auto-deploy<br/>configuration provided by the baseline. The values here are used in the<br/>suggested rules created by Cloud Armor Adaptive Protection. Be aware that<br/>deviating from the baseline could reduce the effectiveness of the security<br/>policy and lead to security violation findings. The description of this<br/>object can be found in the upstream Cloud Armor [module documentation](https://registry.terraform.io/modules/GoogleCloudPlatform/cloud-armor/google/latest). | <pre>object({<br/>    enable      = optional(bool)<br/>    priority    = optional(number)<br/>    action      = optional(string)<br/>    preview     = optional(bool)<br/>    description = optional(string)<br/><br/>    load_threshold              = optional(number)<br/>    confidence_threshold        = optional(number)<br/>    impacted_baseline_threshold = optional(number)<br/>    expiration_sec              = optional(number)<br/><br/>    redirect_type   = optional(string)<br/>    redirect_target = optional(string)<br/><br/>    rate_limit_options = optional(object({<br/>      enforce_on_key      = optional(string)<br/>      enforce_on_key_name = optional(string)<br/><br/>      enforce_on_key_configs = optional(list(object({<br/>        enforce_on_key_name = optional(string)<br/>        enforce_on_key_type = optional(string)<br/>      })))<br/><br/>      exceed_action                        = optional(string)<br/>      rate_limit_http_request_count        = optional(number)<br/>      rate_limit_http_request_interval_sec = optional(number)<br/>      ban_duration_sec                     = optional(number)<br/>      ban_http_request_count               = optional(number)<br/>      ban_http_request_interval_sec        = optional(number)<br/>      exceed_redirect_options = optional(object({<br/>        type   = string<br/>        target = optional(string)<br/>      }))<br/>    }), {})<br/>  })</pre> | `{}` | no |
 | automatic_service_enablement | Controls service enablement behaviour of the module. If set to false, the module will not enabled needed APIs. | `bool` | `true` | no |
 | custom_rules | A map of rules which should be added on top of the rules provided by the<br/>baseline. The key of the map specifies the name of the rule. The<br/>description of this object can be found in the upstream Cloud Armor<br/>[module documentation](https://registry.terraform.io/modules/GoogleCloudPlatform/cloud-armor/google/latest). | <pre>map(object({<br/>    action                            = string<br/>    priority                          = number<br/>    description                       = optional(string)<br/>    preview                           = optional(bool, false)<br/>    expression                        = string<br/>    recaptcha_action_token_site_keys  = optional(list(string))<br/>    recaptcha_session_token_site_keys = optional(list(string))<br/>    redirect_type                     = optional(string, null)<br/>    redirect_target                   = optional(string, null)<br/>    rate_limit_options = optional(object({<br/>      enforce_on_key      = optional(string)<br/>      enforce_on_key_name = optional(string)<br/>      enforce_on_key_configs = optional(list(object({<br/>        enforce_on_key_name = optional(string)<br/>        enforce_on_key_type = optional(string)<br/>      })))<br/>      exceed_action                        = optional(string)<br/>      rate_limit_http_request_count        = optional(number)<br/>      rate_limit_http_request_interval_sec = optional(number)<br/>      ban_duration_sec                     = optional(number)<br/>      ban_http_request_count               = optional(number)<br/>      ban_http_request_interval_sec        = optional(number)<br/>      }),<br/>    {})<br/>    header_action = optional(list(object({<br/>      header_name  = optional(string)<br/>      header_value = optional(string)<br/>    })), [])<br/><br/>    preconfigured_waf_config_exclusions = optional(map(object({<br/>      target_rule_set = string<br/>      target_rule_ids = optional(list(string), [])<br/>      request_header = optional(list(object({<br/>        operator = string<br/>        value    = optional(string)<br/>      })))<br/>      request_cookie = optional(list(object({<br/>        operator = string<br/>        value    = optional(string)<br/>      })))<br/>      request_uri = optional(list(object({<br/>        operator = string<br/>        value    = optional(string)<br/>      })))<br/>      request_query_param = optional(list(object({<br/>        operator = string<br/>        value    = optional(string)<br/>      })))<br/>    })), null)<br/><br/>  }))</pre> | `{}` | no |
 | description | Description of the Cloud Armor security policy. | `string` | `"METRO Baseline Security Policy"` | no |
+| json_parsing | Whether Cloud Armor should parse JSON request bodies before evaluating preconfigured WAF rules. Can be `DISABLED` or `STANDARD`. | `string` | `"DISABLED"` | no |
 | layer_7_ddos_defense_rule_visibility | Visibility level of the layer 7 DDOS rule. Can be set to `STANDARD` or<br/>`PREMIUM`. If set to `PREMIUM`, more detailed insights are provided for any<br/>generated DDoS protection rules. | `string` | `"PREMIUM"` | no |
 | layer_7_ddos_defense_threshold_configs | Values to overwrite the default Adaptive Protection thresholds provided by<br/>the baseline. Be aware that deviating from the baseline could reduce the<br/>effectiveness of the security policy and lead to security violation<br/>findings. The description of this object can be found in the upstream Cloud<br/>Armor [module documentation](https://registry.terraform.io/modules/GoogleCloudPlatform/cloud-armor/google/latest). | <pre>list(object({<br/>    name                                    = optional(string)<br/>    auto_deploy_load_threshold              = optional(number)<br/>    auto_deploy_confidence_threshold        = optional(number)<br/>    auto_deploy_impacted_baseline_threshold = optional(number)<br/>    auto_deploy_expiration_sec              = optional(number)<br/>    detection_load_threshold                = optional(number)<br/>    detection_absolute_qps                  = optional(number)<br/>    detection_relative_to_baseline_qps      = optional(number)<br/>    traffic_granularity_configs = optional(list(object({<br/>      type                     = optional(string)<br/>      value                    = optional(string)<br/>      enable_each_unique_value = optional(bool)<br/>    })))<br/>  }))</pre> | `null` | no |
 | log_level | Cloud Armor policy log level. Can be `NORMAL` or `VERBOSE`. | `string` | `"NORMAL"` | no |
@@ -32,7 +33,7 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | policy | Security policy created |
 <!-- END_TF_DOCS -->
 

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "cloud_armor_policy" {
   name                                   = var.name
   description                            = var.description
   log_level                              = var.log_level
+  json_parsing                           = var.json_parsing
   type                                   = "CLOUD_ARMOR"
   layer_7_ddos_defense_rule_visibility   = var.layer_7_ddos_defense_rule_visibility
   layer_7_ddos_defense_enable            = true

--- a/modules/regional-backend-security-policy/docs/TERRAFORM.md
+++ b/modules/regional-backend-security-policy/docs/TERRAFORM.md
@@ -2,20 +2,20 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | terraform | >= 1.10 |
 | google | >= 6.14, < 8 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | cloud_armor_policy | GoogleCloudPlatform/cloud-armor/google//modules/regional-backend-security-policy | ~> 6.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | project_id | Google Cloud project ID. | `string` | n/a | yes |
 | region | Region in which security policy is created | `string` | n/a | yes |
 | automatic_service_enablement | Controls service enablement behaviour of the module. If set to false, the module will not enabled needed APIs. | `bool` | `true` | no |
@@ -28,6 +28,6 @@
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | policy | Security policy created |
 <!-- END_TF_DOCS -->

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,24 @@ variable "log_level" {
   }
 }
 
+variable "json_parsing" {
+  description = "Whether Cloud Armor should parse JSON request bodies before evaluating preconfigured WAF rules. Can be `DISABLED` or `STANDARD`."
+  type        = string
+  nullable    = false
+  default     = "DISABLED"
+
+  validation {
+    condition     = contains(["DISABLED", "STANDARD"], var.json_parsing)
+    error_message = <<-EOM
+      Invalid JSON parsing mode given: '${var.json_parsing}'
+
+      Supported values are:
+        - DISABLED
+        - STANDARD
+    EOM
+  }
+}
+
 variable "layer_7_ddos_defense_rule_visibility" {
   description = <<-EOM
     Visibility level of the layer 7 DDOS rule. Can be set to `STANDARD` or


### PR DESCRIPTION
Expose the Cloud Armor `json_parsing` option in this wrapper module and pass it through to the underlying Google Cloud Armor module.

The default remains `DISABLED`, so existing consumers keep the current behavior unless they explicitly enable JSON parsing.


We found a false-positive WAF block on an authenticated JSON API behind Cloud Armor.

The affected service sends requests with `Content-Type: application/json`, for example:

```json
{
  "email": "mcss.ca-issue@panel.groups.cf.metro.cloud",
  "managers": ["valentyn.mukhovatyi@metro.digital"]
}
```

Without json parsing enabled Cloud Armor was not cleanly treating the request as structured JSON. It was effectively inspecting the raw JSON body as argument-style input, and the whole body appeared as an “argument name”.