### PR TITLE
ci(commitlint): rename config and exclude dependabot commit lines

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,0 +1,4 @@
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    ignores: [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)],
+};

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,3 +1,0 @@
-{
-    "extends": ["@commitlint/config-conventional"]
-}


### PR DESCRIPTION
Dependabot sometimes creates very long commit messages. This is currently not configurable,
therefor excluding such lines from commit lint
